### PR TITLE
Fix disabled color name

### DIFF
--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -13,7 +13,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
 }) => {
   className = className || "";
   const iconClass = text ? "" : `icon--${name}`;
-  const colorClass = !isDisabled && color ? `icon--${color}` : "icon--black-3";
+  const colorClass = !isDisabled && color ? `icon--${color}` : "icon--black3";
   const selectedClass = isSelected ? "icon-button--selected" : "";
 
   if (onClick) {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -41,7 +41,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
 
   const expandButtonClass = isExpanded ? "select-menu__button--active" : "";
   const expanListClass = isExpanded ? "select-menu__menu--active" : "";
-  const disabledColorClass = isDisabled ? "icon--black-3" : "";
+  const disabledColorClass = isDisabled ? "icon--black3" : "";
 
   return (
     <OutsideClickHandler


### PR DESCRIPTION
Seems like a typo, changed to `black3` according to the [source](https://github.com/thomas-lowry/figma-plugin-ds/blob/master/src/styles/components/_icon.scss#L65)