### PR TITLE
Add input name attributes ref support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -161,6 +161,7 @@ export interface InputProps extends BasicProps {
     value: string,
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
+  name?: string;
   ref?: Ref<HTMLInputElement>;
 }
 
@@ -180,6 +181,7 @@ export interface TextareaProps extends BasicProps {
     value: string,
     event: React.ChangeEvent<HTMLTextAreaElement>
   ) => void;
+  name?: string;
   ref?: Ref<HTMLTextAreaElement>;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Ref } from "react";
 
 export type Icons =
   | "adjust"
@@ -137,6 +137,7 @@ export interface CheckboxProps extends BasicProps {
     value: boolean,
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
+  ref?: Ref<HTMLInputElement>;
 }
 
 export declare const Checkbox: React.FunctionComponent<CheckboxProps>;
@@ -160,6 +161,7 @@ export interface InputProps extends BasicProps {
     value: string,
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
+  ref?: Ref<HTMLInputElement>;
 }
 
 export interface InputWithIconProps extends InputProps, BasicProps {
@@ -178,6 +180,7 @@ export interface TextareaProps extends BasicProps {
     value: string,
     event: React.ChangeEvent<HTMLTextAreaElement>
   ) => void;
+  ref?: Ref<HTMLTextAreaElement>;
 }
 
 export declare const Textarea: React.FunctionComponent<TextareaProps>;

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -1,61 +1,60 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { CheckboxProps } from "../index";
 
-const Checkbox: React.FunctionComponent<CheckboxProps> = ({
-  id,
-  className,
-  type,
-  isDisabled,
-  label,
-  name,
-  defaultValue,
-  onChange,
-}) => {
-  className = className || "";
-  type = type || "checkbox";
-  let inputConfig: any = {
-    id: id || `${type}--${(Math.random() * 100000000).toFixed(0)}`,
-  };
-  switch (type) {
-    case "switch":
-      inputConfig = {
-        ...inputConfig,
-        className: "switch__toggle",
-        type: "checkbox",
-      };
-      break;
-    case "radio":
-      inputConfig = {
-        ...inputConfig,
-        className: "radio__button",
-        type: "radio",
-        name,
-      };
-      break;
-    default:
-      inputConfig = {
-        ...inputConfig,
-        className: "checkbox__box",
-        type: "checkbox",
-      };
-      break;
-  }
-  const labelClass = `${type}__label`;
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (
+    { id, className, type, isDisabled, label, name, defaultValue, onChange },
+    ref
+  ) => {
+    className = className || "";
+    type = type || "checkbox";
+    let inputConfig: any = {
+      name,
+      id: id || `${type}--${(Math.random() * 100000000).toFixed(0)}`,
+      ref,
+    };
+    switch (type) {
+      case "switch":
+        inputConfig = {
+          ...inputConfig,
+          className: "switch__toggle",
+          type: "checkbox",
+        };
+        break;
+      case "radio":
+        inputConfig = {
+          ...inputConfig,
+          className: "radio__button",
+          type: "radio",
+        };
+        break;
+      default:
+        inputConfig = {
+          ...inputConfig,
+          className: "checkbox__box",
+          type: "checkbox",
+        };
+        break;
+    }
+    const labelClass = `${type}__label`;
 
-  return (
-    <div className={`${type} ${className}`}>
-      <input
-        {...inputConfig}
-        defaultChecked={defaultValue}
-        onChange={(event) => onChange && onChange(event.target.checked, event)}
-        disabled={isDisabled}
-      />
-      <label className={labelClass} htmlFor={inputConfig.id}>
-        {label}
-      </label>
-    </div>
-  );
-};
+    return (
+      <div className={`${type} ${className}`}>
+        <input
+          {...inputConfig}
+          defaultChecked={defaultValue}
+          onChange={(event) =>
+            onChange && onChange(event.target.checked, event)
+          }
+          disabled={isDisabled}
+        />
+        <label className={labelClass} htmlFor={inputConfig.id}>
+          {label}
+        </label>
+      </div>
+    );
+  }
+);
 
 export default Checkbox;

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,68 +1,85 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { InputProps, InputWithIconProps } from "../index";
 import { Icon } from "./";
 
-const InputComponent: React.FunctionComponent<InputProps> = ({
-  className = "",
-  type,
-  defaultValue,
-  placeholder,
-  isDisabled,
-  onChange,
-}) => (
-  <input
-    type={type}
-    className={className}
-    placeholder={placeholder}
-    defaultValue={defaultValue}
-    disabled={isDisabled}
-    onChange={(event) => onChange && onChange(event.target.value, event)}
-  />
+const InputComponent = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      name,
+      className = "",
+      type,
+      defaultValue,
+      placeholder,
+      isDisabled,
+      onChange,
+    },
+    ref
+  ) => (
+    <input
+      name={name}
+      type={type}
+      className={className}
+      placeholder={placeholder}
+      defaultValue={defaultValue}
+      disabled={isDisabled}
+      onChange={(event) => onChange && onChange(event.target.value, event)}
+      ref={ref}
+    />
+  )
 );
 
-const Input: React.FunctionComponent<InputWithIconProps> = ({
-  className,
-  type,
-  icon,
-  iconColor = "black3",
-  defaultValue,
-  placeholder,
-  isDisabled,
-  onChange,
-}) => {
-  className = className || "";
-  type = type || "text";
-  const inputClass = "input__field";
+const Input = forwardRef<HTMLInputElement, InputWithIconProps>(
+  (
+    {
+      name,
+      className,
+      type,
+      icon,
+      iconColor = "black3",
+      defaultValue,
+      placeholder,
+      isDisabled,
+      onChange,
+    },
+    ref
+  ) => {
+    className = className || "";
+    type = type || "text";
+    const inputClass = "input__field";
 
-  if (icon) {
-    return (
-      <div className="input input--with-icon">
-        <Icon name={icon} color={iconColor} isDisabled={isDisabled} />
-        <InputComponent
-          className={`${inputClass} ${className}`}
-          type={type}
-          defaultValue={defaultValue}
-          placeholder={placeholder}
-          isDisabled={isDisabled}
-          onChange={onChange}
-        />
-      </div>
-    );
-  } else {
-    return (
-      <div className="input">
-        <InputComponent
-          className={`${inputClass} ${className}`}
-          type={type}
-          defaultValue={defaultValue}
-          placeholder={placeholder}
-          isDisabled={isDisabled}
-          onChange={onChange}
-        />
-      </div>
-    );
+    if (icon) {
+      return (
+        <div className="input input--with-icon">
+          <Icon name={icon} color={iconColor} isDisabled={isDisabled} />
+          <InputComponent
+            name={name}
+            className={`${inputClass} ${className}`}
+            type={type}
+            defaultValue={defaultValue}
+            placeholder={placeholder}
+            isDisabled={isDisabled}
+            onChange={onChange}
+            ref={ref}
+          />
+        </div>
+      );
+    } else {
+      return (
+        <div className="input">
+          <InputComponent
+            className={`${inputClass} ${className}`}
+            type={type}
+            defaultValue={defaultValue}
+            placeholder={placeholder}
+            isDisabled={isDisabled}
+            onChange={onChange}
+            ref={ref}
+          />
+        </div>
+      );
+    }
   }
-};
+);
 
 export default Input;

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -68,6 +68,7 @@ const Input = forwardRef<HTMLInputElement, InputWithIconProps>(
       return (
         <div className="input">
           <InputComponent
+            name={name}
             className={`${inputClass} ${className}`}
             type={type}
             defaultValue={defaultValue}

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -1,26 +1,34 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { TextareaProps } from "../index";
 
-const Textarea: React.FunctionComponent<TextareaProps> = ({
-  className,
-  rows = 2,
-  defaultValue,
-  placeholder,
-  isDisabled,
-  onChange,
-}) => {
-  className = className || "";
-  return (
-    <textarea
-      rows={rows}
-      className={`textarea ${className}`}
-      placeholder={placeholder}
-      defaultValue={defaultValue}
-      disabled={isDisabled}
-      onChange={(event) => onChange && onChange(event.target.value, event)}
-    />
-  );
-};
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      name,
+      className,
+      rows = 2,
+      defaultValue,
+      placeholder,
+      isDisabled,
+      onChange,
+    },
+    ref
+  ) => {
+    className = className || "";
+    return (
+      <textarea
+        name={name}
+        rows={rows}
+        className={`textarea ${className}`}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        disabled={isDisabled}
+        onChange={(event) => onChange && onChange(event.target.value, event)}
+        ref={ref}
+      />
+    );
+  }
+);
 
 export default Textarea;


### PR DESCRIPTION
Allowing inputs to receive `name` attributes as well as refs makes it much easier to work with them.

As it is now it's a pain to work with form libraries like [react-hook-form](https://react-hook-form.com/get-started#IntegratingwithUIlibraries)