### PR TITLE
feat: added titles for select options

### DIFF
--- a/examples/src/ExamplePage.js
+++ b/examples/src/ExamplePage.js
@@ -147,6 +147,15 @@ export default class ExaplePage extends React.Component {
                 ]}
               />
               <Select
+                  placeholder="Select item with titles"
+                  onSelectComponent={this.handleSelectComponent}
+                  options={[
+                    { value: 1, label: "Item 1", title: "Description for Item 1" },
+                    { value: 2, label: "Item 2", title: "Description for Item 2" },
+                    { value: 3, label: "Item 3", title: "Description for Item 3" },
+                  ]}
+              />
+              <Select
                 placeholder="Select item with groups"
                 onSelectComponent={this.handleSelectComponent}
                 options={[

--- a/examples/src/api.js
+++ b/examples/src/api.js
@@ -300,8 +300,8 @@ export const api = {
       name: "options",
       type: "SelectOption[]",
       defaultValue: [
-        { value: 1, label: "Item 1" },
-        { value: 2, label: "Item 2" },
+        { value: 1, label: "Item 1", title: "Item 1 description" },
+        { value: 2, label: "Item 2", title: "Item 2 description" },
       ],
       isRequired: true,
     },

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,7 @@ export interface SelectOption {
   divider?: string | boolean;
   value: string | number | boolean;
   label: string;
+  title?: string;
 }
 
 export interface SelectProps extends BasicProps {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -53,6 +53,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           className={`select-menu__button ${expandButtonClass} ${disabledColorClass}`}
           onClick={handleExpandClick}
           disabled={isDisabled}
+          title={selectedOption?.title}
         >
           <span className="select-menu__label">
             {(selectedOption && selectedOption.label) || placeholder}
@@ -64,7 +65,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
           style={{ top: "-24px" }}
         >
           {options &&
-            options.map(({ value, label, divider }, i) =>
+            options.map(({ value, label, divider, title }, i) =>
               divider ? (
                 <React.Fragment key={`select-option-divider--${i}`}>
                   {divider !== true && (
@@ -86,6 +87,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
                   }`}
                   onClick={() => handleSelectClick(value)}
                   key={`select-option--${i}`}
+                  title={title}
                 >
                   <span className="select-menu__item-icon"></span>
                   <span className="select-menu__item-label">{label}</span>


### PR DESCRIPTION
Added optional field `title` to `SelectOption` to show some long text on hover.
@alexandrtovmach please have a look and if there are no objections I would be thankful to have this in the next version of this library.