### PR TITLE
Add type property to button

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,7 @@ export interface ButtonProps extends BasicProps {
   isTertiary?: boolean;
   isDisabled?: boolean;
   isDestructive?: boolean;
+  type?: "submit" | "button" | "reset";
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -10,8 +10,10 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   isDisabled,
   onClick,
   isDestructive,
+  type,
 }) => {
   className = className || "";
+  type = type || "submit";
   const level = isTertiary ? "tertiary" : isSecondary ? "secondary" : "primary";
   const modificator = isDestructive ? "-destructive" : "";
   if (isSecondary && isTertiary) {
@@ -25,6 +27,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
       onClick={onClick}
       className={`button button--${level}${modificator} ${className}`}
       disabled={isDisabled}
+      type={type}
     >
       {children}
     </button>


### PR DESCRIPTION
This allows users to set the button to be a specific type like `reset` or `button`.

Without the type property every button will submit a form. 

This fixes #21 