### PR TITLE
Allow for controlled checkboxes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,7 @@ export interface CheckboxProps extends BasicProps {
   type?: CheckboxTypes;
   isDisabled?: boolean;
   defaultValue?: boolean;
+  checked?: boolean;
   name?: string;
   onChange?: (
     value: boolean,

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "url": "https://github.com/alexandrtovmach/react-figma-plugin-ds"
   },
   "dependencies": {
-    "figma-plugin-ds": "^0.1.8",
+    "figma-plugin-ds": "^1.0.1",
     "react-outside-click-handler": "^1.3.0"
   }
 }

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -18,6 +18,11 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   let inputConfig: any = {
     id: id || `${type}--${(Math.random() * 100000000).toFixed(0)}`,
   };
+  if (defaultValue && checked) {
+    console.warn(
+      `Use either "defaultValue" to create an uncontrolled component or "checked" to create a controlled component`
+    );
+  }
   switch (type) {
     case "switch":
       inputConfig = {

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -10,6 +10,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   label,
   name,
   defaultValue,
+  checked,
   onChange,
 }) => {
   className = className || "";
@@ -48,6 +49,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
       <input
         {...inputConfig}
         defaultChecked={defaultValue}
+        checked={checked}
         onChange={(event) => onChange && onChange(event.target.checked, event)}
         disabled={isDisabled}
       />


### PR DESCRIPTION
This solves the issue from #11 

> I am retrieving data in the index.tsx from figma via the api. I need to change a toggle depending on the result.
> However I think that due to the missing checked property I am not able to do this. The issue is, that the onmessage event is  not run before the ui is rendered, so when the ui is initialized (and defaultChecked is used) I don't have access to the data yet.

In short: When showing data/settings that are loaded from local storage they are not available on initial component rendering so you need to changed them programmatically. This PR makes this possible.