### PR TITLE
interactive elements handle standard html props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,9 @@ export interface BasicProps {
   className?: string;
 }
 
-export interface ButtonProps extends BasicProps {
+export interface ButtonProps
+  extends BasicProps,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: any;
   isSecondary?: boolean;
   isTertiary?: boolean;
@@ -137,6 +139,7 @@ export interface CheckboxProps extends BasicProps {
     value: boolean,
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
+  initialHtmlInputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 export declare const Checkbox: React.FunctionComponent<CheckboxProps>;
@@ -151,7 +154,9 @@ export interface DisclosureProps extends BasicProps {
 
 export declare const Disclosure: React.FunctionComponent<DisclosureProps>;
 
-export interface InputProps extends BasicProps {
+export interface InputProps
+  extends BasicProps,
+    React.InputHTMLAttributes<HTMLInputElement> {
   placeholder: string;
   type?: "text" | "number" | "password";
   defaultValue?: any;
@@ -169,7 +174,9 @@ export interface InputWithIconProps extends InputProps, BasicProps {
 
 export declare const Input: React.FunctionComponent<InputWithIconProps>;
 
-export interface TextareaProps extends BasicProps {
+export interface TextareaProps
+  extends BasicProps,
+    React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   placeholder: string;
   rows: number;
   defaultValue?: any;
@@ -196,6 +203,7 @@ export interface SelectProps extends BasicProps {
   defaultValue?: string | number | boolean;
   onExpand?: (state: boolean) => void;
   onChange?: (option: SelectOption) => void;
+  unExpandedButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
 export declare const Select: React.FunctionComponent<SelectProps>;
@@ -234,6 +242,7 @@ export interface IconProps extends BasicProps {
   isDisabled?: boolean;
   text?: string;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  iconButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
 export declare const Icon: React.FunctionComponent<IconProps>;

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { ButtonProps } from "../index";
 
 const Button: React.FunctionComponent<ButtonProps> = ({
-  children,
+ children,
   className,
   isSecondary,
   isTertiary,
   isDisabled,
   onClick,
   isDestructive,
+  ...htmlButtonProps
 }) => {
   className = className || "";
   const level = isTertiary ? "tertiary" : isSecondary ? "secondary" : "primary";
@@ -22,6 +23,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
 
   return (
     <button
+      {...htmlButtonProps}
       onClick={onClick}
       className={`button button--${level}${modificator} ${className}`}
       disabled={isDisabled}

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -11,10 +11,12 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   name,
   defaultValue,
   onChange,
+  initialHtmlInputProps
 }) => {
   className = className || "";
   type = type || "checkbox";
   let inputConfig: any = {
+    ...initialHtmlInputProps,
     id: id || `${type}--${(Math.random() * 100000000).toFixed(0)}`,
   };
   switch (type) {

--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -10,6 +10,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
   isSelected,
   isDisabled,
   onClick,
+  iconButtonProps,
 }) => {
   className = className || "";
   const iconClass = text ? "" : `icon--${name}`;
@@ -19,6 +20,7 @@ const Icon: React.FunctionComponent<IconProps> = ({
   if (onClick) {
     return (
       <button
+        {...iconButtonProps}
         style={{
           padding: 0,
           cursor: "default",

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -10,8 +10,10 @@ const InputComponent: React.FunctionComponent<InputProps> = ({
   placeholder,
   isDisabled,
   onChange,
+  ...htmlInputProps
 }) => (
   <input
+  {...htmlInputProps}
     type={type}
     className={className}
     placeholder={placeholder}
@@ -30,6 +32,7 @@ const Input: React.FunctionComponent<InputWithIconProps> = ({
   placeholder,
   isDisabled,
   onChange,
+  ...htmlInputProps
 }) => {
   className = className || "";
   type = type || "text";
@@ -40,6 +43,7 @@ const Input: React.FunctionComponent<InputWithIconProps> = ({
       <div className="input input--with-icon">
         <Icon name={icon} color={iconColor} isDisabled={isDisabled} />
         <InputComponent
+          {...htmlInputProps}
           className={`${inputClass} ${className}`}
           type={type}
           defaultValue={defaultValue}
@@ -53,6 +57,7 @@ const Input: React.FunctionComponent<InputWithIconProps> = ({
     return (
       <div className="input">
         <InputComponent
+          {...htmlInputProps}
           className={`${inputClass} ${className}`}
           type={type}
           defaultValue={defaultValue}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -11,6 +11,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
   defaultValue,
   onExpand,
   onChange,
+  unExpandedButtonProps
 }) => {
   const [isExpanded, onExpandedStateChange] = useState(false);
   const [selectedOption, onSelectOption] = useState(
@@ -50,6 +51,7 @@ const Select: React.FunctionComponent<SelectProps> = ({
     >
       <div className={`select-menu ${className}`}>
         <button
+          {...unExpandedButtonProps}
           className={`select-menu__button ${expandButtonClass} ${disabledColorClass}`}
           onClick={handleExpandClick}
           disabled={isDisabled}

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -9,10 +9,12 @@ const Textarea: React.FunctionComponent<TextareaProps> = ({
   placeholder,
   isDisabled,
   onChange,
+  ...htmlTextAreaProps
 }) => {
   className = className || "";
   return (
     <textarea
+      {...htmlTextAreaProps}
       rows={rows}
       className={`textarea ${className}`}
       placeholder={placeholder}


### PR DESCRIPTION
All interactive elements expose the standard HTML attributes of their main element as optional parameters/props as well

should address this issue:
https://github.com/alexandrtovmach/react-figma-plugin-ds/issues/14
might impact this issue positively:
https://github.com/alexandrtovmach/react-figma-plugin-ds/issues/26